### PR TITLE
Fix "unknown parameter" when canceling subscription

### DIFF
--- a/Charge/Billing.php
+++ b/Charge/Billing.php
@@ -135,7 +135,7 @@ trait Billing
     public function cancel($subscription_id)
     {
         // don't renew at end of period
-        $this->getSubscription($subscription_id)->cancel(['at_period_end' => true]);
+        $this->getSubscription($subscription_id)->cancel(['cancel_at_period_end' => true]);
     }
 
     /**


### PR DESCRIPTION
When canceling a subscription I began getting an error complaining about the `at_period_end` parameter. Apparently it's supposed to be `cancel_at_period_end`. This fixes the error, and cancels the subscription.