### PR TITLE
Update Billing.php

### DIFF
--- a/Charge/Billing.php
+++ b/Charge/Billing.php
@@ -399,6 +399,7 @@ trait Billing
                 'stripeEmail',
                 'stripeToken',
                 'plan',
+                'description',
                 'amount',
                 'amount_dollar',
                 'email',


### PR DESCRIPTION
Noticed that when you pass the description as a hidden form field, it isn't picked up during the Stripe charge process. This resolves that.