### PR TITLE
Update ChargeListener

### DIFF
--- a/Charge/ChargeListener.php
+++ b/Charge/ChargeListener.php
@@ -78,6 +78,8 @@ class ChargeListener extends Listener
             try {
                 // get paid
                 $charge = $this->charge($this->getDetails($submission->data()));
+                
+                event('user.charged', [$submission]);
 
                 // add the charge id to the submission
                 $submission->set('customer_id', $charge['customer']['id']);


### PR DESCRIPTION
Emitting an event that the user has been charged and passing the submission data.

I could see a handful of these events being useful generally. 

In our case, we've added a listener to our own addon listening for the `user.charged` event and then with `$submission` the event is passing, we use that to submit the `$submission` data to an external CRM system.

I get that you won't want to be all things to all people but feel like emitting events is pretty simple.
