### PR TITLE
Use billing email if receipt's email is empty

### DIFF
--- a/Charge/Traits/HandlesWebhook.php
+++ b/Charge/Traits/HandlesWebhook.php
@@ -58,8 +58,11 @@ trait HandlesWebhook
             $user->save();
         }
 
+        $receiptEmail = Arr::get($data, 'charges.data.0.receipt_email');
+        $billingEmail = Arr::get($data, 'charges.data.0.billing_details.email');
+
         (new SendEmailAction)->execute(
-            Arr::get($data, 'charges.data.0.receipt_email'),
+            $receiptEmail ?: $billingEmail,
             'one_time_payment_email_template',
             'one_time_payment_email_subject',
             [


### PR DESCRIPTION
I have seen this in Stripe Webhook's Log after a subscription completed successfully:

**Error:**
```
Type error: Argument 1 passed to Statamic\Addons\Charge\Actions\SendEmailAction::execute() must be of the type string, null given, called in /Code/statamic/site/addons/Charge/Traits/HandlesWebhook.php on line 69
```

**API Body**
```json
"charges": {
    "data": [
        {
            ...
            "object": "charge",
            "billing_details": {
                "address": {
                    "city": null,
                    "country": null,
                    "line1": null,
                    "line2": null,
                    "postal_code": "123456",
                    "state": null
                },
                "email": "test@email.local",
                "name": null,
                "phone": null
            },
            "paid": true,
            "receipt_email": null,
            "receipt_number": null,
            ...
        }
    ]
}
```

This PR allow to use the Billing email as default address if receipt email is empty