### PR TITLE
Support for “Stripe Customer Portal”

### DIFF
--- a/docs/subscription/general.md
+++ b/docs/subscription/general.md
@@ -198,3 +198,17 @@ Supported Parameters:
 {{ /charge:cancel_subscription_form }}
 
 ```
+
+### Customer Portal
+
+Assumes a logged in user.
+
+Use this tag to create a temporary link to the [Stripe Customer Portal](https://stripe.com/docs/billing/subscriptions/customer-portal).
+
+```
+{{ charge:customer_portal :id="customer_id" }}
+    <a href="{{ url }}" target="_blank">
+        Customer Portal
+    </a>
+{{ /charge:customer_portal }}
+```


### PR DESCRIPTION
Allow customers to manage their subscriptions and billing details: https://stripe.com/docs/billing/subscriptions/customer-portal