### PR TITLE
Added “charge:prices” tag

### DIFF
--- a/Charge/ChargeTags.php
+++ b/Charge/ChargeTags.php
@@ -10,12 +10,14 @@ use Stripe\SetupIntent;
 use Statamic\Extend\Tags;
 use Stripe\PaymentIntent;
 use Statamic\Addons\Charge\Traits\Billing;
+use Statamic\Addons\Charge\Traits\HasPrices;
 use Statamic\Addons\Charge\Traits\HasProducts;
 use Statamic\Addons\Charge\Traits\HasSubscriptions;
 
 class ChargeTags extends Tags
 {
     use Billing;
+    use HasPrices;
     use HasProducts;
     use HasSubscriptions;
 

--- a/Charge/Traits/HasPrices.php
+++ b/Charge/Traits/HasPrices.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Statamic\Addons\Charge\Traits;
+
+use Stripe\Price;
+
+trait HasPrices
+{
+    /**
+     * The {{ charge:prices }} tag.
+     *
+     * @return string
+     */
+    public function prices()
+    {
+        $type = $this->getParam('type');
+        $limit = $this->getParamInt('limit', 10);
+        $active = $this->getParam('active');
+        $product = $this->getParam('product');
+
+        $params = [
+            'limit' => $limit,
+        ];
+
+        if (! is_null($active)) {
+            $params['active'] = (bool) $active;
+        }
+
+        if ($type) {
+            $params['type'] = $type;
+        }
+
+        if ($product) {
+            $params['product'] = $product;
+        }
+
+        $prices = Price::all($params)->toArray();
+
+        return $this->parseLoop($prices['data']);
+    }
+}


### PR DESCRIPTION
This PR add a new `{{ charge:prices }}` tag that allows to retrieve all product's prices, even if is set as "ONE TIME" price.

An example on how use the tag:
```html
{{ charge:prices :product="product:id" scope="price" }}
    {{ if price:recurring }}
        <div>Price: {{ price:unit_amount divide="100" }} / {{ price:recurring:interval }}</div>
    {{ else }}
        <div>Price: {{ price:unit_amount divide="100" }}</div>
    {{ /if }}
{{ /charge:prices }}
```

Here a reference Stripe docs: https://stripe.com/docs/api/prices/list